### PR TITLE
make test suite work with Perl 5.8.8

### DIFF
--- a/t/04-oop.t
+++ b/t/04-oop.t
@@ -73,7 +73,8 @@ $rules->{checks} = [
     my $v = Validate::Tiny->new(
         filters => {
             only_digits => sub {
-                my $val = shift // return;
+                my $val = shift;
+                return unless defined $val;
                 $val =~ s/\D//g;
                 return $val;
             }

--- a/t/filters/04-custom.t
+++ b/t/filters/04-custom.t
@@ -6,7 +6,8 @@ use Validate::Tiny ':all';
 use Test::More;
 
 $Validate::Tiny::FILTERS{only_digits} = sub {
-    my $val = shift // return;
+    my $val = shift;
+    return unless defined $val;
     $val =~ s/\D//g;
     return $val;
 };


### PR DESCRIPTION
Module does not appear to require 5.10, but the test does.  Please consider this patch to make it work on older Perls, or specify 5.10 as a prereq.